### PR TITLE
Pull Request - Changed route order

### DIFF
--- a/backend/src/routes/enemyRouter.ts
+++ b/backend/src/routes/enemyRouter.ts
@@ -7,9 +7,9 @@ const router = express.Router();
 router.use(requireAuth);
 router.post("/confirm", enemyController.confirmAddEnemy);
 router.get("/isEnemy/:enemyUserId", enemyController.isEnemy);
-router.get("/:userId", enemyController.getEnemy);
 router.post("/", enemyController.addEnemy);
 router.delete("/", enemyController.removeEnemy);
 router.get("/", enemyController.getEnemiesList);
+router.get("/:userId", enemyController.getEnemy);
 
 export default router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "DogParkPals",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This fixes the 500 errors issue Mark encountered when making this call:
```
 await api.post('/api/enemies', {
           userId: currentUser.id,
           enemyUserId: userId
 });
```
Just had to put the routes in the correct order.