### PR TITLE
fix: correct DATABASE_URL path for backend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3000
-      - DATABASE_URL=file:./prisma/prod.db
+      - DATABASE_URL=file:./data/prod.db
     env_file:
       - ./docker-secrets
     volumes:


### PR DESCRIPTION
The backend service was still using the old DATABASE_URL path (file:./prisma/prod.db) instead of the updated path (file:./data/prod.db) that matches the volume mount (backend-db:/app/data).

This brings it in line with db-init and backup-events services which already had the correct path.