### PR TITLE
Invalidate tokens and prevent signin for deleted users

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -24,6 +24,11 @@ const authController = {
         throw NotFoundError('User not found');
       }
 
+      // Prevent deleted_user sentinel from signing in
+      if (user.username === 'deleted_user') {
+        throw AuthError('This account cannot be used');
+      }
+
       const isValidPassword = await verifyPassword(password, user.password_hash);
       if (!isValidPassword) {
         throw AuthError('Invalid credentials');

--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -2,6 +2,9 @@ import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { AuthError } from '../utils/errors';
 import { isTokenBlacklisted } from '../utils/tokenBlacklist';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
 
 interface JwtPayload {
   userId: number;
@@ -9,7 +12,7 @@ interface JwtPayload {
   role?: string;
 }
 
-export const requireAuth = (req: Request, _res: Response, next: NextFunction) => {
+export const requireAuth = async (req: Request, _res: Response, next: NextFunction) => {
   try {
     let token = req.cookies.authToken;
     if (!token) {
@@ -32,6 +35,16 @@ export const requireAuth = (req: Request, _res: Response, next: NextFunction) =>
     if (isTokenBlacklisted(token)) {
       throw AuthError('Invalid authentication token');
     }
+
+    // Verify user still exists and is not deleted
+    const user = await prisma.user.findUnique({ where: { id: decoded.userId } });
+    if (!user) {
+      throw AuthError('User account has been deleted');
+    }
+    if (user.username === 'deleted_user') {
+      throw AuthError('This account cannot be used');
+    }
+
     req.userId = decoded.userId;
     req.user = { id: decoded.userId, role: decoded.role };
 
@@ -47,7 +60,7 @@ export const requireAuth = (req: Request, _res: Response, next: NextFunction) =>
   }
 };
 
-export const optionalAuth = (req: Request, _res: Response, next: NextFunction) => {
+export const optionalAuth = async (req: Request, _res: Response, next: NextFunction) => {
   try {
     let token = req.cookies.authToken;
     if (!token) {
@@ -70,6 +83,16 @@ export const optionalAuth = (req: Request, _res: Response, next: NextFunction) =
       if (isTokenBlacklisted(token)) {
         return next(AuthError('Invalid authentication token'));
       }
+
+      // Verify user still exists and is not deleted
+      const user = await prisma.user.findUnique({ where: { id: decoded.userId } });
+      if (user && user.username === 'deleted_user') {
+        return next(AuthError('This account cannot be used'));
+      }
+      if (!user) {
+        return next();
+      }
+
       req.userId = decoded.userId;
       req.user = { id: decoded.userId, role: decoded.role };
     next();

--- a/backend/src/tests/authController.test.ts
+++ b/backend/src/tests/authController.test.ts
@@ -91,6 +91,19 @@ describe('Auth Controller', () => {
       expect(awardExperience).toHaveBeenCalledWith(1, XP_REWARDS.LOGIN, 'login');
     });
 
+    test('blocks login for deleted_user sentinel account', async () => {
+      mockReq.body = { email: 'deleted@example.com', password: 'password123' };
+      mockGetUserByEmail.mockResolvedValue({ id: 999, email: 'deleted@example.com', username: 'deleted_user', password_hash: 'hashed' });
+      mockVerifyPassword.mockResolvedValue(true);
+
+      await authController.login(mockReq as Request, mockRes as Response, mockNext);
+
+      const forwarded = mockNext.mock.calls[0][0] as unknown as AppError;
+      expect(forwarded.statusCode).toBe(401);
+      expect(forwarded.code).toBe('AUTH_ERROR');
+      expect(forwarded.message).toContain('cannot be used');
+    });
+
     test('forwards not found when user missing', async () => {
       mockReq.body = { email: 'missing@example.com', password: 'password123' };
       mockGetUserByEmail.mockResolvedValue(null);

--- a/backend/src/tests/integration/authUsers.test.ts
+++ b/backend/src/tests/integration/authUsers.test.ts
@@ -562,3 +562,45 @@ describe("user profile picture upload", () => {
     expect(res.body.code).toBe("AUTH_ERROR");
   });
 });
+
+describe("auth token expiration and deleted user validation", () => {
+  test("token is rejected after user deletion", async () => {
+    // Create a test user
+    const createRes = await request(app)
+      .post("/users")
+      .send({ username: "tokentest", email: "tokentest@example.com", password: "password123" });
+
+    expect(createRes.status).toBe(201);
+    const userId = createRes.body.id;
+
+    // Login and get token
+    const loginRes = await request(app)
+      .post("/auth/login")
+      .send({ email: "tokentest@example.com", password: "password123" });
+
+    expect(loginRes.status).toBe(200);
+    const userToken = loginRes.body.token;
+
+    // Verify token works before deletion
+    const beforeDelete = await request(app)
+      .get("/users/presence")
+      .set("Authorization", `Bearer ${userToken}`);
+
+    expect(beforeDelete.status).toBe(200);
+
+    // Delete the user as admin
+    const deleteRes = await request(app)
+      .delete(`/users/${userId}`)
+      .set("Authorization", `Bearer ${adminToken()}`);
+
+    expect(deleteRes.status).toBe(204);
+
+    // Verify token is now rejected
+    const afterDelete = await request(app)
+      .get("/users/presence")
+      .set("Authorization", `Bearer ${userToken}`);
+
+    expect(afterDelete.status).toBe(401);
+    expect(afterDelete.body.code).toBe("AUTH_ERROR");
+  });
+});


### PR DESCRIPTION
# PR: Invalidate Tokens and Block Sign-In for Deleted Users

## Summary
This PR tightens authentication behavior for deleted accounts by ensuring tokens tied to deleted users can no longer be used, and by preventing the deleted_user sentinel account from signing in.

## What Changed
- Blocked sign-in for the deleted_user sentinel account.
- Updated authentication middleware to verify the user still exists for authenticated requests.
- Rejected tokens that reference users who were deleted after token issuance.
- Added tests for sentinel sign-in blocking and token rejection after user deletion.

## Files Updated
- backend/src/controllers/authController.ts
- backend/src/middlewares/authMiddleware.ts
- backend/src/tests/authController.test.ts
- backend/src/tests/integration/authUsers.test.ts

## Behavior Changes
### Before
- A token could remain valid even if the corresponding user was deleted.
- The deleted_user sentinel account could potentially authenticate if credentials matched.

### After
- Requests with tokens for deleted users are rejected with AUTH_ERROR.
- The deleted_user sentinel account cannot sign in.
- Auth middleware confirms user existence before granting authenticated context.

## Test Coverage
- Added/updated unit tests in authController test suite.
- Added integration test verifying a token becomes unusable after account deletion.

Validated suites:
- npm test -- src/tests/authController.test.ts src/tests/authorizationMiddleware.test.ts
- npm run test:integration -- src/tests/integration/authUsers.test.ts

## Notes
- This complements existing session disconnect behavior on deletion by covering stateless JWT usage after deletion.
- Error response shape remains consistent with existing API conventions.
